### PR TITLE
feat(CORS): set headers to resolve CORS errors issue on clients

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,21 @@ const app = express();
 // app.use(bodyParser.urlencoded()); //  x-www-form-urlencoded Use with form <form>
 app.use(bodyParser.json()); //  application/json
 
+// CORS
+app.use((req, res, next) => {
+  //  Allow origin and can access all clients using wildcard
+  res.setHeader('Access-Control-Allow-Origin', '*');
+
+  //  Allow request method or can use a wildcard to allow all methods
+  res.setHeader('Access-Control-Allow-Methods', 'GET');
+
+  //  Allow authorization
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+
+  // Request can now continue and can be handled by our routes
+  next();
+});
+
 app.use('/feed', feedRoutes);
 
 app.listen(8080);


### PR DESCRIPTION
# Changes
- Setup a middleware to register to allow CORS origin.
- Adding set header to modify access


# Screenshot

Testing run client-side code sample on codepen.io
<img width="1157" alt="Screen Shot 2565-09-11 at 13 45 37" src="https://user-images.githubusercontent.com/50129987/189515786-ae5bc59b-6926-4b8e-8691-3a78ee8f9a31.png">

Clicked the **Get posts** button and then Inspect the client's console

<img width="783" alt="Screen Shot 2565-09-11 at 13 46 01" src="https://user-images.githubusercontent.com/50129987/189515808-0cb79282-1edb-4ef6-adb9-e59b2c77f3a3.png">


# Documentation
What is `app.use()` in express.js? https://stackoverflow.com/questions/11321635/nodejs-express-what-is-app-use