### PR TITLE
fix(sorting): Sorting post latest come on first place

### DIFF
--- a/controllers/feed.js
+++ b/controllers/feed.js
@@ -18,6 +18,7 @@ exports.getPosts = async (req, res, next) => {
     // Limit the post per page
     const posts = await Post.find()
       .populate('creator')
+      .sort({ created: -1 })
       .skip((currentPage - 1) * perPage)
       .limit(perPage);
 


### PR DESCRIPTION
# What are changes?
- Sorting post
- The latest post that is added will come first 